### PR TITLE
Reject past times

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
           - "28.1"
           - "snapshot"
         cask_version:
-          - "0.8.0"
-          - "0.8.4"
           - "snapshot"
     steps:
       - uses: actions/checkout@v3
@@ -42,7 +40,7 @@ jobs:
 
       - uses: conao3/setup-cask@master
         with:
-          version: "snapshot"
+          version: ${{ matrix.cask_version }}
 
       - name: lint with cask
         run: cask build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
   push:
     paths-ignore:
-      - '**.mp3'
-      - '**.md'
-      - '**.org'
-      - '.dir-locals.el'
+      - "**.mp3"
+      - "**.md"
+      - "**.org"
+      - ".dir-locals.el"
     branches:
       - master
+      - develop
+      - fix/*
 
 jobs:
   build:
@@ -17,22 +19,22 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - '25.1'
-          - '25.3'
-          - '26.1'
-          - '26.3'
-          - '27.2'
-          - 'snapshot'
+          - "25.1"
+          - "25.3"
+          - "26.1"
+          - "26.3"
+          - "27.2"
+          - "28.1"
+          - "snapshot"
         cask_version:
-          - '0.8.0'
-          - '0.8.4'
-          - 'snapshot'
+          - "0.8.0"
+          - "0.8.4"
+          - "snapshot"
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.6'
-          architecture: 'x64'
+          python-version: "3.10"
 
       - uses: purcell/setup-emacs@master
         with:
@@ -40,7 +42,7 @@ jobs:
 
       - uses: conao3/setup-cask@master
         with:
-          version: 'snapshot'
+          version: "snapshot"
 
       - name: lint with cask
         run: cask build

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 An alarm clock for Emacs
 
+Derived from [wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock).
+
 ## Requirements
 
 -   Emacs 24 or higher
@@ -14,27 +16,30 @@ An alarm clock for Emacs
 
 ## Get started
 
--   Via [MELPA](https://melpa.org).
-
 -   Get alarm-clock
     -   Manually download alarm-clock and set-up your load path.
-
 -   To auto-start alarm-clock every time you open Emacs add these lines to your .emacs file:
 
-          (require 'alarm-clock) ; Not needed if you use package.el
+          (require 'alarm-clock)
 
 ## Basic Usage
 
 ### `alarm-clock-set`
 
-Set an alarm clock with the time following tips.  
-TIME can be "6"(6 seconds), "11 minutes", "10 hours", "11:40pm", etc.  
+Set an alarm clock with the time following tips.
+TIME can be "6"(6 seconds), "11 minutes", "10 hours", "11:40pm", etc.
 MESSAGE will be shown when notifying at setting time.
 
 ### `alarm-clock-list-view`
 
-Display the alarm clock list.  
-Use `a` to set a new alarm clock, `C-k` to delete current alarm clock.
+Display the alarm clock list.
+Use `a` to set a new alarm clock, `d` or `C-k` to delete current alarm
+clock, `g` to refresh the view, and space (`' '`) to turn off
+a ringing alarm (M-x alarm-clock-stop).
+
+### `alarm-clock-stop`
+
+Turn off the currently ringing alarm.
 
 ### `alarm-clock-save`
 
@@ -44,13 +49,40 @@ Save alarm-clock to cache file.
 
 Restore alarm-clock from cache file.
 
+## Enhancements
+
+This fork of
+[wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock) adds these features:
+
+-   Allow repeating the alarm clock sound multiple times,
+    asynchornously, or until stopped via M-x alarm-clock-stop
+    or by pressing the SPACE key in the alarm list window.
+-   Allow alarm-clock-list-view to work even if there are no alarms,
+-   Bind `i` and `+` to alarm-clock-set
+-   Bind `-` to alarm-clock-delete
+-   Bind SPACE to stop alarm-clock-stop
+-   Show time remaining until the alarm fires in the alarm list view. Press `g` to refresh.
+-   Aligned the header-line-format with content
+-   Sort alarms by increasing time (earliest first) in alarm-clock-list-view
+-   New customization variables in the `alarm-clock` group:
+    - `alarm-clock-play-sound-repeat`: Number of times to repeat the
+      sound when an alarm rings. Default is 1. Use M-x alarm-clock-stop
+      to stop ringing the alarm.
+    - `alarm-clock-play-auto-view-alarms`: If non-nil, display the alarm
+    clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop
+-   Change alarm-clock-save to use find-file-noselect/save-buffer so that
+    we have ~ backups of the save file
+-   Added alarm-clock--unexpired-alarms
+-   Renamed from alarm-clock--turn-autosave-?? to alarm-clock-turn-autosave-??
+    since they need not be internal function.
+-   Improved doc strings on alarm-clock-turn-autosave-on / alarm-clock-turn-autosave-off
+
 ## Configurations
 
 ### Enable autosave-and-restore feature
 
--   Change cache file path by setting the variable `alarm-clock-cache-file` to any file path you like.  
-
--   Add these lines to your .emacs file:
+-   Change cache file path by setting the variable `alarm-clock-cache-file` to any file path you like.
+-   Add these lines to your `.emacs` file:
 
           (alarm-clock--turn-autosave-on)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 An alarm clock for Emacs
 
-Derived from [wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock).
 
 ## Requirements
 
@@ -15,27 +14,28 @@ Derived from [wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock).
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 
 ## Get started
+- Via [MELPA](https://melpa.org).
 
 -   Get alarm-clock
     -   Manually download alarm-clock and set-up your load path.
 -   To auto-start alarm-clock every time you open Emacs add these lines to your .emacs file:
 
-          (require 'alarm-clock)
+          (require 'alarm-clock) ; Not needed if you use package.el
 
 ## Basic Usage
 
 ### `alarm-clock-set`
 
-Set an alarm clock with the time following tips.
-TIME can be "6"(6 seconds), "11 minutes", "10 hours", "11:40pm", etc.
+Set an alarm clock with the time following tips.  
+TIME can be "6"(6 seconds), "11 minutes", "10 hours", "11:40pm", etc.  
 MESSAGE will be shown when notifying at setting time.
 
 ### `alarm-clock-list-view`
 
-Display the alarm clock list.
-Use `a` to set a new alarm clock, `d` or `C-k` to delete current alarm
-clock, `g` to refresh the view, and space (`' '`) to turn off
-a ringing alarm (M-x alarm-clock-stop).
+Display the alarm clock list.  
+Use `a` to set a new alarm clock, `d` or `C-k` to delete current alarm  
+clock, `g` to refresh the view, and space (`' '`) to turn off  
+a ringing alarm (M-x alarm-clock-stop).  
 
 ### `alarm-clock-stop`
 
@@ -49,33 +49,6 @@ Save alarm-clock to cache file.
 
 Restore alarm-clock from cache file.
 
-## Enhancements
-
-This fork of
-[wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock) adds these features:
-
--   Allow repeating the alarm clock sound multiple times,
-    asynchornously, or until stopped via M-x alarm-clock-stop
-    or by pressing the SPACE key in the alarm list window.
--   Allow alarm-clock-list-view to work even if there are no alarms,
--   Bind `i` and `+` to alarm-clock-set
--   Bind `-` to alarm-clock-delete
--   Bind SPACE to stop alarm-clock-stop
--   Show time remaining until the alarm fires in the alarm list view. Press `g` to refresh.
--   Aligned the header-line-format with content
--   Sort alarms by increasing time (earliest first) in alarm-clock-list-view
--   New customization variables in the `alarm-clock` group:
-    - `alarm-clock-play-sound-repeat`: Number of times to repeat the
-      sound when an alarm rings. Default is 1. Use M-x alarm-clock-stop
-      to stop ringing the alarm.
-    - `alarm-clock-play-auto-view-alarms`: If non-nil, display the alarm
-    clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop
--   Change alarm-clock-save to use find-file-noselect/save-buffer so that
-    we have ~ backups of the save file
--   Added alarm-clock--unexpired-alarms
--   Renamed from alarm-clock--turn-autosave-?? to alarm-clock-turn-autosave-??
-    since they need not be internal function.
--   Improved doc strings on alarm-clock-turn-autosave-on / alarm-clock-turn-autosave-off
 
 ## Configurations
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An alarm clock for Emacs
 
 -   Emacs 24 or higher
 -   [mpg123](http://mpg123.org) (gnu/linux)
+-   [mpg123](http://mpg123.org) (windows)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ An alarm clock for Emacs
 ## Requirements
 
 -   Emacs 24 or higher
--   [mpg123](http://mpg123.org) (gnu/linux)
--   [mpg123](http://mpg123.org) (windows)
+-   [mpg123](http://mpg123.org) (gnu/linux & windows)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Restore alarm-clock from cache file.
 -   Change cache file path by setting the variable `alarm-clock-cache-file` to any file path you like.
 -   Add these lines to your `.emacs` file:
 
-          (alarm-clock--turn-autosave-on)
+          (alarm-clock-turn-autosave-on)
 
 ## Q & A
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An alarm clock for Emacs
 ## Requirements
 
 -   Emacs 24 or higher
--   [mpg123](http://mpg123.org) (gnu/linux & windows)
+-   [mpg123](http://mpg123.org) (gnu/linux, Cygwin and Windows)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -34,6 +34,7 @@
 ;;; Code:
 
 (require 'parse-time)
+(require 'alert)
 
 (defgroup alarm-clock nil
   "An alarm clock management."
@@ -64,6 +65,11 @@
   :group 'alarm-clock)
 
 (defcustom alarm-clock-system-notify t
+  "Whether to notify via system based notification feature."
+  :type 'boolean
+  :group 'alarm-clock)
+
+(defcustom alarm-clock-alert-notify t
   "Whether to notify via system based notification feature."
   :type 'boolean
   :group 'alarm-clock)
@@ -272,6 +278,8 @@ and 'mpg123' in linux"
        (alarm-clock-list-view))
   (when alarm-clock-play-sound
     (alarm-clock--ding))
+  (when alarm-clock-alert-notify
+    (alert message :title title))
   (when alarm-clock-system-notify
     (alarm-clock--system-notify title message))
   (message (format "[%s] - %s" title message)))

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -245,9 +245,10 @@ MESSAGE will be shown when notifying in the status bar."
 (defun alarm-clock--ding ()
   "Play ding.
 In osx operating system, 'afplay' will be used to play sound,
-and 'mpg123' in linux"
+and 'mpg123' in linux or windows"
   (let ((program (cond ((eq system-type 'darwin) "afplay")
                        ((eq system-type 'gnu/linux) "mpg123")
+                       ((eq system-type 'windows-nt) "mpg123")
                        (t "")))
         (sound (expand-file-name alarm-clock-sound-file)))
     (when (and (executable-find program)

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -43,7 +43,7 @@
 
 (defcustom alarm-clock-sound-file
   (concat
-   (file-name-directory (or load-file-name buffer-file-name))
+   (file-name-directory (locate-library "alarm-clock"))
    "alarm.mp3")
   "File to play the alarm sound."
   :type 'file

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -163,7 +163,7 @@ MESSAGE will be shown when notifying in the status bar."
   (let* ((format "%-20s %-12s   %s")
          (inhibit-read-only t) )
     (erase-buffer)
-    (setq header-line-format (format format " Time" " Remaining" " Message"))
+    (setq header-line-format (format format "Time" "Remaining" "Message"))
     (dolist (alarm (alarm-clock--sort-list))
       (let* ((alarm-time (plist-get alarm :time))
              (alarm-message (plist-get alarm :message))
@@ -220,7 +220,7 @@ MESSAGE will be shown when notifying in the status bar."
                  (- repeat 1)
                  )))
 
-(defun alarm-clock--ding () ;; (alarm-clock--ding)
+(defun alarm-clock--ding ()
   "Play ding.
 In osx operating system, 'afplay' will be used to play sound,
 and 'mpg123' in linux"
@@ -302,11 +302,15 @@ and 'mpg123' in linux"
     (cancel-timer (plist-get alarm :timer)))
   (setq alarm-clock--alist nil))
 
-(defun alarm-clock-turn-autosave-on ()
+(defalias 'alarm-clock-turn-autosave-on 'alarm-clock--turn-autosave-on)
+
+(defun alarm-clock--turn-autosave-on ()
   "Enable saving the alarm when killing emacs"
   (add-hook 'kill-emacs-hook #'alarm-clock-save))
 
-(defun alarm-clock-turn-autosave-off ()
+(defalias 'alarm-clock-turn-autosave-off 'alarm-clock--turn-autosave-off)
+
+(defun alarm-clock--turn-autosave-off ()
   "Disable auto-saving the alarm when killing emacs"
   (remove-hook 'kill-emacs-hook #'alarm-clock-save))
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -118,7 +118,6 @@ Auto-save the alarms if alarm-clock-auto-save is true."
 (defun alarm-clock--set (time message)
   "Set an alarm clock at time TIME.
 MESSAGE will be shown when notifying in the status bar."
-  (interactive "sAlarm at (e.g: 10:00am, 2 minutes, 30 seconds): \nsMessage: ")
   (let* ((time (if (stringp time) (string-trim time) time))
          (message (string-trim message))
          (timer (run-at-time

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -249,6 +249,7 @@ and 'mpg123' in linux or windows"
   (let ((program (cond ((eq system-type 'darwin) "afplay")
                        ((eq system-type 'gnu/linux) "mpg123")
                        ((eq system-type 'windows-nt) "mpg123")
+                       ((eq system-type 'cygwin) "mpg123")
                        (t "")))
         (sound (expand-file-name alarm-clock-sound-file)))
     (when (and (executable-find program)

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -34,7 +34,7 @@
 ;;; Code:
 
 (require 'parse-time)
-(require 'alert)
+(require 'alert nil t)
 
 (defgroup alarm-clock nil
   "An alarm clock management."
@@ -278,7 +278,7 @@ and 'mpg123' in linux"
        (alarm-clock-list-view))
   (when alarm-clock-play-sound
     (alarm-clock--ding))
-  (when alarm-clock-alert-notify
+  (when (and alarm-clock-alert-notify (fboundp 'alert))
     (alert message :title title))
   (when alarm-clock-system-notify
     (alarm-clock--system-notify title message))


### PR DESCRIPTION
reject times that are in the past

improve layout and formatting of the header line, and set fringe to 0 so data lines line up under headers